### PR TITLE
feat: add all build targets from gateway-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-musleabihf
           - mips-unknown-linux-musl
+          - arm-unknown-linux-gnueabihf
     steps:
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,14 @@ jobs:
       matrix:
         target:
           - mipsel-unknown-linux-musl
+          - mips-unknown-linux-musl
           - aarch64-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-musleabihf
+          - armv7-unknown-linux-gnueabihf
           - mips-unknown-linux-musl
           - arm-unknown-linux-gnueabihf
+          - armv5te-unknown-linux-musleabi
     steps:
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Add all build targets currently supported for gateway-rs

List from https://github.com/helium/gateway-rs#supported-platforms

Related to #9