### PR TITLE
Add bench command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -146,9 +152,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
+]
 
 [[package]]
 name = "digest"
@@ -176,13 +185,13 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
  "der",
  "elliptic-curve",
- "hmac",
+ "rfc6979",
  "signature",
 ]
 
@@ -210,24 +219,26 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "decb3a27ea454a5f23f96eb182af0671c12694d64ecc33dada74edd1301f6cfc"
 dependencies = [
  "crypto-bigint",
+ "der",
  "ff",
  "generic-array",
  "group",
  "rand_core 0.6.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -281,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -301,8 +312,8 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.3.1"
-source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.3.1#33ac71d8e54dbb644dff0cbc8ca5b1ef482f03a0"
+version = "0.3.2"
+source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.3.2#f5ea6ca4242c0130d75a6db821d1efae55685068"
 dependencies = [
  "bs58",
  "ecc608-linux",
@@ -387,11 +398,13 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.9.0"
-source = "git+https://github.com/helium/elliptic-curves?branch=madninja/compact_point_impl#b3051010e5f3c05430ed556a0165291322ac2fa5"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e0c5310031b5d4528ac6534bccc1446c289ac45c47b277d5aa91089c5f74fa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
 ]
 
@@ -511,10 +524,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ serde = "1"
 rand = "0.8"
 serde_json = "1"
 angry-purple-tiger = "0"
-helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.3.1", features = ["ecc608"]}
+helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.3.2", features = ["ecc608"]}
 

--- a/src/cmd/bench.rs
+++ b/src/cmd/bench.rs
@@ -1,0 +1,51 @@
+use crate::cmd::*;
+use helium_crypto::Sign;
+use rand::{rngs::OsRng, RngCore};
+use serde_json::json;
+use std::time::{Duration, Instant};
+
+/// Run a benchmark test.
+///
+/// This reports number of signing operations per second a security part can
+/// handle
+#[derive(Debug, StructOpt)]
+pub struct Cmd {
+    /// Slot to use for benchmark
+    pub slot: u8,
+
+    /// Number of iterations to use for test
+    #[structopt(long, default_value = "1000")]
+    pub iterations: u32,
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result {
+        let keypair = with_ecc(|ecc| compact_key_in_slot(ecc, self.slot))?;
+        let duration = bench_sign(&keypair, self.iterations)?;
+        let rate = self.iterations as f64 / duration.as_secs_f64();
+        let avg_ms = duration.as_millis() as f64 / self.iterations as f64;
+        let json = json!({
+            "iterations": self.iterations,
+            "avg_ms": round2(avg_ms),
+            "rate": round2(rate),
+        });
+        print_json(&json)
+    }
+}
+
+fn round2(v: f64) -> f64 {
+    (v * 100.0).round() / 100.0
+}
+
+fn bench_sign(keypair: &Keypair, iterations: u32) -> Result<Duration> {
+    let mut total_duration = Duration::new(0, 0);
+    for _ in 1..iterations {
+        let mut data = [0u8; 32];
+        OsRng.try_fill_bytes(&mut data)?;
+
+        let start = Instant::now();
+        let _signature = keypair.sign(&data)?;
+        total_duration += start.elapsed();
+    }
+    Ok(total_duration)
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -8,6 +8,7 @@ pub use helium_crypto::{
 };
 pub use structopt::{clap::arg_enum, StructOpt};
 
+pub mod bench;
 pub mod config;
 pub mod info;
 pub mod key;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ pub enum Cmd {
     Provision(cmd::provision::Cmd),
     Config(cmd::config::Cmd),
     Test(cmd::test::Cmd),
+    Bench(cmd::bench::Cmd),
 }
 
 pub fn main() -> Result {
@@ -41,6 +42,7 @@ impl Cmd {
             Self::Provision(cmd) => cmd.run(),
             Self::Config(cmd) => cmd.run(),
             Self::Test(cmd) => cmd.run(),
+            Self::Bench(cmd) => cmd.run(),
         }
     }
 }


### PR DESCRIPTION
This adds a `bench` command to the application. The command takes the slot to run against and an optional number of iterations to use to calculate average signing time and signing operations per second

Run the bench: 

```shell
gateway_mfr bench 0 --iterations 100
```