### PR TITLE
Adjust expected/found parameters in check function to actual use

### DIFF
--- a/src/device/ecc.rs
+++ b/src/device/ecc.rs
@@ -237,7 +237,7 @@ fn check_zone_locked(zone: &ecc608::Zone) -> TestResult {
     }
 }
 
-fn check<T>(name: &'static str, expected: T, found: T) -> (&'static str, test::TestOutcome)
+fn check<T>(name: &'static str, found: T, expected: T) -> (&'static str, test::TestOutcome)
 where
     T: fmt::Display + PartialEq,
 {


### PR DESCRIPTION
The `test` command currently reports expected and found values as swapped. This is due to the `check` function being used differently than declared (`expected` and `found` parameters swapped). Compare, e.g., to [#L287](https://github.com/helium/gateway-mfr-rs/blob/main/src/device/ecc.rs#L287=):
```
check("auth_key", config.auth_key(), 0),
```

It should, thus, be `check(name, found, expected)`.
(the use of `test::expected` seems to be fine throughout, though, cf. [src/device/mod.rs#70](https://github.com/helium/gateway-mfr-rs/blob/main/src/device/mod.rs#L70=))