### PR TITLE
Convert to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,30 +42,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "base16ct"
@@ -153,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,17 +166,39 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -353,6 +361,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "ff"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +413,7 @@ dependencies = [
  "angry-purple-tiger",
  "anyhow",
  "bytes",
+ "clap",
  "helium-crypto",
  "http",
  "rand",
@@ -391,7 +421,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "structopt",
 ]
 
 [[package]]
@@ -434,12 +463,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "helium-crypto"
@@ -466,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -517,6 +543,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +610,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -640,6 +694,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "p256"
@@ -797,6 +857,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,33 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -979,12 +1029,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1035,28 +1085,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "uninitialized"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c1aa4511c38276c548406f0b1f5f8b793f000cfb51e18f278a102abd057e81"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1098,10 +1130,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-structopt = "0"
+clap = {version = "4", features = ["derive"]}
 anyhow = "1"
 semver = "0"
 serde = {version = "1", features = ["derive"]}

--- a/src/cmd/bench.rs
+++ b/src/cmd/bench.rs
@@ -3,16 +3,15 @@ use helium_crypto::{Keypair, Sign};
 use rand::{rngs::OsRng, RngCore};
 use serde_json::json;
 use std::time::{Duration, Instant};
-use structopt::StructOpt;
 
 /// Run a benchmark test.
 ///
 /// This reports number of signing operations per second a security part can
 /// handle
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Args)]
 pub struct Cmd {
     /// Number of iterations to use for test
-    #[structopt(long, short, default_value = "100")]
+    #[arg(long, short, default_value_t = 100)]
     pub iterations: u32,
 }
 

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,8 +1,7 @@
 use crate::{cmd::print_json, Device, Result};
-use structopt::StructOpt;
 
-/// Gets the zone, slot or key config for a given ecc slot
-#[derive(Debug, StructOpt)]
+/// Gets the security device configuration
+#[derive(Debug, clap::Args)]
 pub struct Cmd {}
 
 impl Cmd {

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -1,8 +1,7 @@
 use crate::{cmd::print_json, device::Device, Result};
-use structopt::StructOpt;
 
 /// Get ecc chip information
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Args)]
 pub struct Cmd {}
 
 impl Cmd {

--- a/src/cmd/key.rs
+++ b/src/cmd/key.rs
@@ -2,17 +2,13 @@ use crate::{cmd::print_json, Device, Result};
 use angry_purple_tiger::AnimalName;
 use helium_crypto::Keypair;
 use serde_json::json;
-use structopt::StructOpt;
 
-/// Prints public key information for a given slot.
-///
-/// WARNING: Using the generate option will generate a new keypair in the given
-/// slot.
-#[derive(Debug, StructOpt)]
+/// Prints public key information from the security device
+#[derive(Debug, clap::Args)]
 pub struct Cmd {
     /// Generate a new private key in the slot. WARNING: This will overwrite the
-    /// existing key in the slot
-    #[structopt(long)]
+    /// existing private key on the security device.
+    #[arg(long)]
     pub generate: bool,
 }
 

--- a/src/cmd/provision.rs
+++ b/src/cmd/provision.rs
@@ -1,10 +1,7 @@
 use crate::{cmd::key::print_keypair, Device, Result};
-use structopt::StructOpt;
 
-/// Configures the ECC for gateway/miner use. This includes configuring slot and
-/// key configs for †he given slot, locking the data and config zone and generating an ecc compact
-/// key in the configured slot.
-#[derive(Debug, StructOpt)]
+/// Configures the security device for gateway/miner use.
+#[derive(Debug, clap::Args)]
 pub struct Cmd {}
 
 impl Cmd {

--- a/src/cmd/test.rs
+++ b/src/cmd/test.rs
@@ -8,10 +8,9 @@ use crate::{
 };
 use serde_json::json;
 use std::collections::HashMap;
-use structopt::StructOpt;
 
 /// Read the slot configuration for a given slot
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Args)]
 pub struct Cmd {}
 
 impl Cmd {

--- a/src/device/ecc.rs
+++ b/src/device/ecc.rs
@@ -18,7 +18,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Device {
     /// The i2c/swi device path
     pub path: PathBuf,

--- a/src/device/file.rs
+++ b/src/device/file.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Device {
     /// The file device path
     pub path: PathBuf,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -13,7 +13,7 @@ mod tpm;
 /// A security device to work with. Security devices come in all forms. This
 /// abstracts them into one with a well defined interface for doing what this
 /// tool needs to do with them.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Device {
     #[cfg(feature = "ecc608")]
     Ecc(ecc::Device),
@@ -146,14 +146,14 @@ impl FromStr for Device {
     fn from_str(s: &str) -> Result<Self> {
         let url: Uri = s
             .parse()
-            .map_err(|err| anyhow!("invalid device url \"{}\": {:?}", s, err))?;
+            .map_err(|err| anyhow!("invalid device url \"{s}\": {err:?}"))?;
         match url.scheme_str() {
             #[cfg(feature = "ecc608")]
             Some("ecc") => Ok(Self::Ecc(ecc::Device::from_url(&url)?)),
             #[cfg(feature = "tpm")]
             Some("tpm") => Ok(Self::Tpm(tpm::Device::from_url(&url)?)),
             Some("file") | None => Ok(Self::File(file::Device::from_url(&url)?)),
-            _ => Err(anyhow!("invalid device url \"{}\"", s)),
+            _ => Err(anyhow!("invalid device url \"{s}\"")),
         }
     }
 }

--- a/src/device/tpm.rs
+++ b/src/device/tpm.rs
@@ -10,7 +10,7 @@ use crate::{
     Result,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Device {
     /// TPM key path
     pub path: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,28 @@
+use clap::Parser;
 use gateway_mfr::{cmd, Device, Result};
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = env!("CARGO_BIN_NAME"), version = env!("CARGO_PKG_VERSION"), about = "Gateway Manufacturing ")]
+#[derive(Debug, Parser)]
+#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(name = env!("CARGO_BIN_NAME"))]
 pub struct Cli {
-    /// The security device to use
-    #[structopt(long, default_value = "ecc://i2c-1")]
+    /// The security device to use.
+    ///
+    /// The URL for the security device is dependent on the device type being
+    /// used.
+    ///
+    /// Examples:
+    ///
+    /// ecc608 - "ecc://i2c-1", "ecc://i2c-1:96?slot=0"
+    /// file - "file:///etc/keypair.bin"\n
+    /// tpm - "tpm://tpm/<key_path>"
+    #[arg(long, verbatim_doc_comment)]
     device: Device,
 
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     cmd: Cmd,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum Cmd {
     Info(cmd::info::Cmd),
     Key(cmd::key::Cmd),
@@ -23,7 +33,7 @@ pub enum Cmd {
 }
 
 pub fn main() -> Result {
-    let cli = Cli::from_args();
+    let cli = Cli::parse();
     cli.cmd.run(&cli.device)
 }
 


### PR DESCRIPTION
This converts from the mostly deprecated StructOpt to the Clap crate for argument parsing.

As part of this conversion the CLI help commands are also cleanedup to be less ECC specific since TPM is also supported (when feature enabled)