### PR TITLE
fix: naming regression

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,7 +26,7 @@ args = [
 description = "Package application"
 workspace = false
 condition = { env_set = ["CARGO_MAKE_PROFILE", "CROSS_TARGET"]}
-env = { PKG_NAME = "gateway-mfr-${CARGO_MAKE_CRATE_VERSION}-${CARGO_MAKE_PROFILE}" }
+env = { PKG_NAME = "gateway-mfr-v${CARGO_MAKE_CRATE_VERSION}-${CARGO_MAKE_PROFILE}" }
 script = '''
   ${TAR} -zcv -C target/${CROSS_TARGET}/release -f ${PKG_NAME}.tar.gz gateway_mfr
   sha256sum --tag ${PKG_NAME}.tar.gz > ${PKG_NAME}.checksum


### PR DESCRIPTION
The URL structure for releases used to be:

https://github.com/helium/gateway-mfr-rs/releases/download/v0.2.2/gateway-mfr-v0.2.2-arm-unknown-linux-gnueabihf.tar.gz

And now it is:

https://github.com/helium/gateway-mfr-rs/releases/download/v0.4.1/gateway-mfr-0.4.1-arm-unknown-linux-gnueabihf.tar.gz

Notice the missing v in the second part.

Having the v in both places makes things easier for automated actions. (Or, rather, having the filename use the same format as the tag, so could achieve the same thing by instead removing the v from the tag if that's a preferred solution?)

