### PR TITLE
Report duration of each iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_urlencoded = "*"
 http = "0"
 bytes = "*"
 angry-purple-tiger = "0"
-helium-crypto = { version = ">=0.8" }
+helium-crypto = { git = "https://github.com/joecryptotoo/helium-crypto-rs.git", branch = "joecryptotoo/wake_fix" }
 
 [features]
 default = ["ecc608"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,5 @@ helium-crypto = { git = "https://github.com/joecryptotoo/helium-crypto-rs.git", 
 default = ["ecc608"]
 tpm = ["helium-crypto/tpm"]
 ecc608 = ["helium-crypto/ecc608"]
+raspi = ["ecc608", "helium-crypto/raspi"]
 nova-tz = ["helium-crypto/nova-tz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,5 @@ helium-crypto = { version = ">=0.8" }
 default = ["ecc608"]
 tpm = ["helium-crypto/tpm"]
 ecc608 = ["helium-crypto/ecc608"]
+raspi = ["ecc608", "helium-crypto/raspi"]
 nova-tz = ["helium-crypto/nova-tz"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM rust:1.71.0
+
+WORKDIR /usr/src/gateway-mfr-rs
+
+COPY . .
+
+RUN cargo build

--- a/src/cmd/bench.rs
+++ b/src/cmd/bench.rs
@@ -18,13 +18,14 @@ pub struct Cmd {
 impl Cmd {
     pub fn run(&self, device: &Device) -> Result {
         let keypair = device.get_keypair(false)?;
-        let duration = bench_sign(&keypair, self.iterations)?;
+        let (duration, durations) = bench_sign(&keypair, self.iterations)?;
         let rate = self.iterations as f64 / duration.as_secs_f64();
         let avg_ms = duration.as_millis() as f64 / self.iterations as f64;
         let json = json!({
             "iterations": self.iterations,
             "avg_ms": round2(avg_ms),
             "rate": round2(rate),
+            "durations": durations.into_iter().map(|d| d.as_millis()).collect::<Vec<_>>(),
         });
         print_json(&json)
     }
@@ -34,15 +35,18 @@ fn round2(v: f64) -> f64 {
     (v * 100.0).round() / 100.0
 }
 
-fn bench_sign(keypair: &Keypair, iterations: u32) -> Result<Duration> {
+fn bench_sign(keypair: &Keypair, iterations: u32) -> Result<(Duration, Vec<Duration>)> {
     let mut total_duration = Duration::new(0, 0);
+    let mut durations = Vec::new();
     for _ in 1..iterations {
         let mut data = [0u8; 32];
         OsRng.try_fill_bytes(&mut data)?;
 
         let start = Instant::now();
         let _signature = keypair.sign(&data)?;
-        total_duration += start.elapsed();
+        let duration = start.elapsed();
+        total_duration += duration;
+        durations.push(duration);
     }
-    Ok(total_duration)
+    Ok((total_duration, durations))
 }

--- a/src/cmd/bench.rs
+++ b/src/cmd/bench.rs
@@ -38,9 +38,9 @@ fn round2(v: f64) -> f64 {
 fn bench_sign(keypair: &Keypair, iterations: u32) -> Result<(Duration, Vec<Duration>)> {
     let mut total_duration = Duration::new(0, 0);
     let mut durations = Vec::new();
+    let data = [0u8; 32];
     for _ in 0..iterations {
-        let mut data = [0u8; 32];
-        OsRng.try_fill_bytes(&mut data)?;
+        /// OsRng.try_fill_bytes(&mut data)?;
 
         let start = Instant::now();
         let _signature = keypair.sign(&data)?;

--- a/src/cmd/bench.rs
+++ b/src/cmd/bench.rs
@@ -38,7 +38,7 @@ fn round2(v: f64) -> f64 {
 fn bench_sign(keypair: &Keypair, iterations: u32) -> Result<(Duration, Vec<Duration>)> {
     let mut total_duration = Duration::new(0, 0);
     let mut durations = Vec::new();
-    for _ in 1..iterations {
+    for _ in 0..iterations {
         let mut data = [0u8; 32];
         OsRng.try_fill_bytes(&mut data)?;
 

--- a/src/cmd/bench.rs
+++ b/src/cmd/bench.rs
@@ -13,6 +13,9 @@ pub struct Cmd {
     /// Number of iterations to use for test
     #[arg(long, short, default_value_t = 100)]
     pub iterations: u32,
+    /// Flag to enable durations in the results
+    #[arg(long, short)]
+    pub durations: bool,
 }
 
 impl Cmd {
@@ -21,12 +24,15 @@ impl Cmd {
         let (duration, durations) = bench_sign(&keypair, self.iterations)?;
         let rate = self.iterations as f64 / duration.as_secs_f64();
         let avg_ms = duration.as_millis() as f64 / self.iterations as f64;
-        let json = json!({
+        let mut json = json!({
             "iterations": self.iterations,
             "avg_ms": round2(avg_ms),
             "rate": round2(rate),
-            "durations": durations.into_iter().map(|d| d.as_millis()).collect::<Vec<_>>(),
         });
+        if self.durations {
+            json.as_object_mut().unwrap().insert("durations".to_string(), 
+            json!(durations.into_iter().map(|d| d.as_millis()).collect::<Vec<_>>()));
+        }
         print_json(&json)
     }
 }

--- a/src/cmd/bench.rs
+++ b/src/cmd/bench.rs
@@ -38,9 +38,9 @@ fn round2(v: f64) -> f64 {
 fn bench_sign(keypair: &Keypair, iterations: u32) -> Result<(Duration, Vec<Duration>)> {
     let mut total_duration = Duration::new(0, 0);
     let mut durations = Vec::new();
-    let data = [0u8; 32];
     for _ in 0..iterations {
-        /// OsRng.try_fill_bytes(&mut data)?;
+        let mut data = [0u8; 32];
+        OsRng.try_fill_bytes(&mut data)?;
 
         let start = Instant::now();
         let _signature = keypair.sign(&data)?;


### PR DESCRIPTION
docker-compose.yml for testing:

```
---
version: "2.1"
services:

  gateway-mfr-rs:
    build:
      context: https://github.com/joecryptotoo/gateway-mfr-rs.git#bench
    cap_add:
      - SYS_RAWIO
    devices:
      - /dev/i2c-1:/dev/i2c-1
    command: /usr/src/gateway-mfr-rs/target/debug/gateway_mfr --device ecc://i2c-1:96 bench -i 3
 ```
 
 Just run `docker compose up` and this should build from my bench branch and run.